### PR TITLE
Add OnMetal for Kubernetes Cluster

### DIFF
--- a/corekube-onmetal.yaml
+++ b/corekube-onmetal.yaml
@@ -24,7 +24,17 @@
        description: |
          Must be a valid Rackspace Cloud Server flavor for the region you have
          selected to deploy into.
-   flavor_admin:
+   flavor_discovery:
+     type: string
+     default: 4 GB General Purpose v1
+     constraints:
+     - allowed_values:
+       - 4 GB General Purpose v1
+       - 8 GB General Purpose v1
+       description: |
+         Must be a valid Rackspace Cloud Server flavor for the region you have
+         selected to deploy into.
+   flavor_overlord:
      type: string
      default: 4 GB General Purpose v1
      constraints:
@@ -38,7 +48,11 @@
      type: string
      description: Rackspace Cloud Servers CoreOS Stable (633.1.0) UUID
      default: "97646707-08ba-4b9c-bd85-91e976ebcadf"
-   coreos_image_admin:
+   coreos_image_discovery:
+     type: string
+     description: Rackspace Cloud Servers CoreOS Stable (633.1.0) UUID
+     default: "a41d8b7c-d41b-4369-a180-0734f3b1cd8c"
+   coreos_image_overlord:
      type: string
      description: Rackspace Cloud Servers CoreOS Stable (633.1.0) UUID
      default: "a41d8b7c-d41b-4369-a180-0734f3b1cd8c"
@@ -68,8 +82,8 @@
      type: OS::Nova::Server
      properties:
        key_name: { get_param: keyname }
-       image: { get_param: coreos_image_admin }
-       flavor: { get_param: flavor_admin }
+       image: { get_param: coreos_image_discovery }
+       flavor: { get_param: flavor_discovery }
        name: "discovery"
        user_data_format: RAW
        config_drive: "true"
@@ -128,8 +142,8 @@
      type: OS::Nova::Server
      properties:
        key_name: { get_param: keyname }
-       image: { get_param: coreos_image_admin }
-       flavor: { get_param: flavor_admin }
+       image: { get_param: coreos_image_overlord }
+       flavor: { get_param: flavor_overlord }
        name: "overlord"
        user_data_format: RAW
        config_drive: "true"
@@ -245,10 +259,12 @@
                    content: |
                      [Unit]
                      Description=creates etcd environment
+                     After=network-online.target
+                     Requires=network-online.target
 
                      [Service]
                      Type=oneshot
-                     ExecStart=/bin/sh -c "sed -i \"s/=:/=`ifconfig bond0.401 | grep 'inet ' | awk '{print $2}'`:/\" /run/systemd/system/etcd.service.d/20-cloudinit.conf && systemctl daemon-reload"
+                     ExecStart=/bin/sh -c "sed -i \"s/=:/=`ifconfig %kubernetes_net_interface% | grep 'inet ' | awk '{print $2}'`:/\" /run/systemd/system/etcd.service.d/20-cloudinit.conf && systemctl daemon-reload"
                  - name: fleet.service
                    command: start
                  - name: get_discovery_ip_port.service
@@ -360,10 +376,12 @@
                        content: |
                          [Unit]
                          Description=creates etcd environment
+                         After=network-online.target
+                         Requires=network-online.target
 
                          [Service]
                          Type=oneshot
-                         ExecStart=/bin/sh -c "sed -i \"s/=:/=`ifconfig bond0.401 | grep 'inet ' | awk '{print $2}'`:/\" /run/systemd/system/etcd.service.d/20-cloudinit.conf && systemctl daemon-reload"
+                         ExecStart=/bin/sh -c "sed -i \"s/=:/=`ifconfig %kubernetes_net_interface% | grep 'inet ' | awk '{print $2}'`:/\" /run/systemd/system/etcd.service.d/20-cloudinit.conf && systemctl daemon-reload"
                      - name: fleet.service
                        command: start
                      - name: flannel-install.service

--- a/corekube-onmetal.yaml
+++ b/corekube-onmetal.yaml
@@ -48,8 +48,8 @@
          selected to deploy into.
    coreos_image_cluster:
      type: string
-     description: Rackspace Cloud Servers CoreOS Stable (633.1.0) UUID
-     default: "97646707-08ba-4b9c-bd85-91e976ebcadf"
+     description: Rackspace OnMetal CoreOS Stable (633.1.0) UUID
+     default: "84997bd3-7cdf-4405-8075-137d631f24b4"
    coreos_image_discovery:
      type: string
      description: Rackspace Cloud Servers CoreOS Stable (633.1.0) UUID

--- a/corekube-onmetal.yaml
+++ b/corekube-onmetal.yaml
@@ -57,7 +57,7 @@
    kubernetes_net_interface:
      type: string
      description: Host network interface for which Kubernetes' overlay will operate over
-     default: "eth1"
+     default: "bond0.401"
 
  resources:
 
@@ -215,11 +215,6 @@
            template: |
              #cloud-config
              write_files:
-               - path: /etc/environment
-                 permissions: '0755'
-                 content: |
-                   COREOS_PUBLIC_IPV4=%public_ip%
-                   COREOS_PRIVATE_IPV4=%private_ip%
                - path: /run/get_discovery_ip_port.sh
                  permissions: '0755'
                  content: |
@@ -245,6 +240,15 @@
                units:
                  - name: etcd.service
                    command: start
+                 - name: create-etcd-env.service
+                   command: start
+                   content: |
+                     [Unit]
+                     Description=creates etcd environment
+
+                     [Service]
+                     Type=oneshot
+                     ExecStart=/bin/sh -c "sed -i \"s/=:/=`ifconfig bond0.401 | grep 'inet ' | awk '{print $2}'`:/\" /run/systemd/system/etcd.service.d/20-cloudinit.conf && systemctl daemon-reload"
                  - name: fleet.service
                    command: start
                  - name: get_discovery_ip_port.service
@@ -311,8 +315,6 @@
                      [Install]
                      WantedBy=multi-user.target
            params:
-             "%private_ip%": { get_attr: [kubernetes_master, networks, private, 0] }
-             "%public_ip%": { get_attr: [kubernetes_master, networks, public, 0] }
              "%discovery%": { get_attr: [discovery, networks, private, 0] }
              "%uuid%": { get_attr: [coreos_cluster_uuid, value] }
              "%flannel_url%": { get_param: flannel_url }
@@ -338,12 +340,6 @@
              str_replace:
                template: |
                  #cloud-config
-                 write_files:
-                   - path: /etc/environment
-                     permissions: '0755'
-                     content: |
-                       COREOS_PUBLIC_IPV4=%public_ip%
-                       COREOS_PRIVATE_IPV4=%private_ip%
                  coreos:
                    etcd:
                      name: kubernetes_minion_%index%
@@ -359,6 +355,15 @@
                    units:
                      - name: etcd.service
                        command: start
+                     - name: create-etcd-env.service
+                       command: start
+                       content: |
+                         [Unit]
+                         Description=creates etcd environment
+
+                         [Service]
+                         Type=oneshot
+                         ExecStart=/bin/sh -c "sed -i \"s/=:/=`ifconfig bond0.401 | grep 'inet ' | awk '{print $2}'`:/\" /run/systemd/system/etcd.service.d/20-cloudinit.conf && systemctl daemon-reload"
                      - name: fleet.service
                        command: start
                      - name: flannel-install.service
@@ -411,8 +416,6 @@
                          [Install]
                          WantedBy=multi-user.target
                params:
-                 "%private_ip%": { get_attr: [ {get_resource: kubernetes_minions}, networks, private, 0] }
-                 "%public_ip%": { get_attr: [ {get_resource: kubernetes_minions}, networks, public, 0] }
                  "%discovery%": { get_attr: [discovery, networks, private, 0] }
                  "%uuid%": { get_attr: [coreos_cluster_uuid, value] }
                  "%flannel_url%": { get_param: flannel_url }

--- a/corekube-onmetal.yaml
+++ b/corekube-onmetal.yaml
@@ -50,12 +50,6 @@
    coreos_cluster_uuid:
      type: OS::Heat::RandomString
 
-   priv_network:
-     type: Rackspace::Cloud::Network
-     properties:
-       label: kubernetes
-       cidr: 192.168.3.0/24
-
    discovery:
      type: OS::Nova::Server
      properties:
@@ -200,7 +194,6 @@
        networks:
        - uuid: "00000000-0000-0000-0000-000000000000"
        - uuid: "11111111-1111-1111-1111-111111111111"
-       - uuid: { get_resource: priv_network }
        user_data_format: RAW
        config_drive: "true"
        user_data:
@@ -318,7 +311,6 @@
            networks:
            - uuid: "00000000-0000-0000-0000-000000000000"
            - uuid: "11111111-1111-1111-1111-111111111111"
-           - uuid: { get_resource: priv_network }
            user_data_format: RAW
            config_drive: "true"
            user_data:

--- a/corekube-onmetal.yaml
+++ b/corekube-onmetal.yaml
@@ -215,6 +215,11 @@
            template: |
              #cloud-config
              write_files:
+               - path: /etc/environment
+                 permissions: '0755'
+                 content: |
+                   COREOS_PUBLIC_IPV4=%public_ip%
+                   COREOS_PRIVATE_IPV4=%private_ip%
                - path: /run/get_discovery_ip_port.sh
                  permissions: '0755'
                  content: |
@@ -306,6 +311,8 @@
                      [Install]
                      WantedBy=multi-user.target
            params:
+             "%private_ip%": { get_attr: [kubernetes_master, networks, private, 0] }
+             "%public_ip%": { get_attr: [kubernetes_master, networks, public, 0] }
              "%discovery%": { get_attr: [discovery, networks, private, 0] }
              "%uuid%": { get_attr: [coreos_cluster_uuid, value] }
              "%flannel_url%": { get_param: flannel_url }
@@ -331,6 +338,12 @@
              str_replace:
                template: |
                  #cloud-config
+                 write_files:
+                   - path: /etc/environment
+                     permissions: '0755'
+                     content: |
+                       COREOS_PUBLIC_IPV4=%public_ip%
+                       COREOS_PRIVATE_IPV4=%private_ip%
                  coreos:
                    etcd:
                      name: kubernetes_minion_%index%
@@ -398,6 +411,8 @@
                          [Install]
                          WantedBy=multi-user.target
                params:
+                 "%private_ip%": { get_attr: [ {get_resource: kubernetes_minions}, networks, private, 0] }
+                 "%public_ip%": { get_attr: [ {get_resource: kubernetes_minions}, networks, public, 0] }
                  "%discovery%": { get_attr: [discovery, networks, private, 0] }
                  "%uuid%": { get_attr: [coreos_cluster_uuid, value] }
                  "%flannel_url%": { get_param: flannel_url }

--- a/corekube-onmetal.yaml
+++ b/corekube-onmetal.yaml
@@ -1,0 +1,412 @@
+ heat_template_version: 2013-05-23
+
+ description: Deploy a CoreOS cluster that operates a Kubernetes cluster
+
+ parameters:
+   kubernetes_minion_count:
+     description: Number of CoreOS machines to deploy as Kubernetes Minion
+     type: number
+     default: 3
+     constraints:
+     - range:
+         min: 1
+         max: 12
+       description: Must be between 2 and 12 servers.
+   keyname:
+     type: string
+     description: Name of keypair to be used for compute instance
+   flavor:
+     type: string
+     default: OnMetal Compute v1
+     constraints:
+     - allowed_values:
+       - OnMetal Compute v1
+       description: |
+         Must be a valid Rackspace Cloud Server flavor for the region you have
+         selected to deploy into.
+   coreos_image:
+     type: string
+     description: Rackspace Cloud Servers CoreOS Stable (633.1.0) UUID
+     default: "97646707-08ba-4b9c-bd85-91e976ebcadf"
+   git_command:
+     type: string
+     description: Git repo checkout command
+     default: "/usr/bin/git clone https://github.com/metral/overlord ; /usr/bin/git -C overlord checkout -qf 96574056d0cc7ad8e52228df76374cb3537af8ba"
+   flannel_url:
+     type: string
+     description: Flannel (0.4.0) Binary URL
+     default: "http://a26736f09be9784cb06f-8d30bd32035bc1ac3e9215d2d6eedfc5.r53.cf1.rackcdn.com/flanneld"
+   discovery_net_interface:
+     type: string
+     description: Host network interface for which the Discovery node will operate over
+     default: "eth1"
+   kubernetes_net_interface:
+     type: string
+     description: Host network interface for which Kubernetes' overlay will operate over
+     default: "eth2"
+
+ resources:
+
+   coreos_cluster_uuid:
+     type: OS::Heat::RandomString
+
+   priv_network:
+     type: Rackspace::Cloud::Network
+     properties:
+       label: kubernetes
+       cidr: 192.168.3.0/24
+
+   discovery:
+     type: OS::Nova::Server
+     properties:
+       key_name: { get_param: keyname }
+       image: { get_param: coreos_image }
+       flavor: { get_param: flavor }
+       name: "discovery"
+       user_data_format: RAW
+       config_drive: "true"
+       user_data:
+         str_replace:
+           template: |
+             #cloud-config
+             write_files:
+               - path: /run/get_discovery_interface_ip.sh
+                 permissions: '0755'
+                 content: |
+                   #!/bin/bash
+                   # Get's the IP of the interface that discovery will be
+                   # accessible over
+                   DISCOVERY_IF=%discovery_net_interface%
+                   /usr/bin/ip -4 addr show $DISCOVERY_IF | /usr/bin/awk '/inet/ {print $2}' | /usr/bin/cut -d/ -f1 > /run/IP
+                   /usr/bin/sed -i 's/^/IP=/' /run/IP
+             coreos:
+               update:
+                 group: stable
+                 reboot-strategy: off
+               units:
+                 - name: private-discovery-setup.service
+                   command: start
+                   content: |
+                     [Unit]
+                     After=network-online.target
+                     Requires=network-online.target
+
+                     [Service]
+                     ExecStart=/usr/bin/bash /run/get_discovery_interface_ip.sh
+                 - name: private-discovery.service
+                   command: start
+                   content: |
+                     [Unit]
+                     After=network-online.target private-discovery-setup.service
+                     Requires=network-online.target private-discovery-setup.service
+
+                     [Service]
+                     EnvironmentFile=/run/IP
+                     RestartSec=5s
+                     ExecStartPre=/usr/bin/docker pull quay.io/coreos/etcd:v2.0.9
+                     ExecStart=/usr/bin/docker run -d --name discovery \
+                       -p 2379:2379 -p 2380:2380 \
+                       -v /usr/share/ca-certificates/:/etc/ssl/certs \
+                       --net host quay.io/coreos/etcd:v2.0.9 -name discovery \
+                       -initial-advertise-peer-urls http://${IP}:2380,http://${IP}:7001 \
+                       -listen-peer-urls http://${IP}:2380,http://${IP}:7001 \
+                       -initial-cluster discovery=http://${IP}:2380,discovery=http://${IP}:7001 \
+                       -advertise-client-urls http://${IP}:2379,http://${IP}:4001 \
+                       -listen-client-urls http://0.0.0.0:2379,http://0.0.0.0:4001
+           params:
+             "%discovery_net_interface%": { get_param: discovery_net_interface }
+
+   overlord:
+     type: OS::Nova::Server
+     properties:
+       key_name: { get_param: keyname }
+       image: { get_param: coreos_image }
+       flavor: { get_param: flavor }
+       name: "overlord"
+       user_data_format: RAW
+       config_drive: "true"
+       user_data:
+         str_replace:
+           template: |
+             #cloud-config
+             coreos:
+               etcd:
+                 name: overlord
+                 discovery: http://%discovery%:2379/v2/keys/discovery/%uuid%
+                 addr: $private_ipv4:4001
+                 peer-addr: $private_ipv4:7001
+               update:
+                 group: stable
+                 reboot-strategy: off
+               units:
+                 - name: etcd.service
+                   command: start
+                 - name: fleet.socket
+                   command: start
+                   content: |
+                     [Socket]
+                     # Talk to the API over a Unix domain socket (default)
+                     ListenStream=/var/run/fleet.sock
+
+                     # Talk to the API over an exposed port
+                     ListenStream=10001
+                     Service=fleet-local.service
+
+                     [Install]
+                     WantedBy=sockets.target
+                 - name: fleet-local.service
+                   command: start
+                   content: |
+                     # fleet-local is kicked off by fleet.socket after API port
+                     # is opened
+                     [Unit]
+                     Description=fleet-local
+                     Wants=etcd.service
+                     After=etcd.service
+
+                     [Service]
+                     Environment=FLEET_PUBLIC_IP=$private_ipv4
+                     Environment=FLEET_METADATA=kubernetes_role=overlord
+                     ExecStart=/usr/bin/fleet
+                     Restart=always
+                     RestartSec=10s
+                 - name: overlord.service
+                   command: start
+                   content: |
+                     # Overlord / logic layer service to deploy kubernetes to
+                     # the cluster
+                     [Unit]
+                     After=network-online.target
+                     Requires=network-online.target
+
+                     [Service]
+                     WorkingDirectory=/root
+                     Environment="DIR=overlord"
+                     ExecStartPre=/usr/bin/rm -rf $DIR
+                     ExecStartPre=%git_command%
+                     ExecStart=/usr/bin/bash ${DIR}/build_run.sh
+           params:
+             "%discovery%": { get_attr: [discovery, networks, private, 0] }
+             "%uuid%": { get_attr: [coreos_cluster_uuid, value] }
+             "%git_command%": { get_param: git_command }
+
+   kubernetes_master:
+     type: OS::Nova::Server
+     properties:
+       key_name: { get_param: keyname }
+       image: { get_param: coreos_image }
+       flavor: { get_param: flavor }
+       name: "kubernetes_master"
+       networks:
+       - uuid: "00000000-0000-0000-0000-000000000000"
+       - uuid: "11111111-1111-1111-1111-111111111111"
+       - uuid: { get_resource: priv_network }
+       user_data_format: RAW
+       config_drive: "true"
+       user_data:
+         str_replace:
+           template: |
+             #cloud-config
+             write_files:
+               - path: /run/get_discovery_ip_port.sh
+                 permissions: '0755'
+                 content: |
+                   #!/bin/bash
+                   # Sets up environment file with the discovery node's IP &
+                   # port so # that in Overlode's template 
+                   # master-apiserver@.service it can be passed 
+                   # in as an argument
+                   /usr/bin/cat /run/systemd/system/etcd.service.d/20-cloudinit.conf | /usr/bin/grep -i discovery | /usr/bin/cut -f3 -d"=" | /usr/bin/awk -F '/v' '{print $1}' > /run/discovery_ip_port
+                   /usr/bin/sed -i 's/^/DISCOVERY_IP_PORT=/' /run/discovery_ip_port
+             coreos:
+               etcd:
+                 name: kubernetes_master
+                 discovery: http://%discovery%:2379/v2/keys/discovery/%uuid%
+                 addr: $private_ipv4:4001
+                 peer-addr: $private_ipv4:7001
+               fleet:
+                 public-ip: $private_ipv4
+                 metadata: kubernetes_role=master
+               update:
+                 group: stable
+                 reboot-strategy: off
+               units:
+                 - name: etcd.service
+                   command: start
+                 - name: fleet.service
+                   command: start
+                 - name: get_discovery_ip_port.service
+                   runtime: true
+                   command: start
+                   content: |
+                     # Runs get_discovery_ip_port.sh to have discovery IP &
+                     # port ready for consumption by overlord when creating
+                     # the Kubernetes' master-api@.service template
+                     [Unit]
+                     After=network-online.target
+                     Requires=network-online.target
+
+                     [Service]
+                     ExecStart=/usr/bin/bash /run/get_discovery_ip_port.sh
+                 - name: flannel-install.service
+                   command: start
+                   content: |
+                     # Installs flannel
+                     [Unit]
+                     After=network-online.target
+                     Requires=network-online.target
+
+                     [Service]
+                     Type=oneshot
+                     RemainAfterExit=yes
+                     ExecStart=/usr/bin/wget -N -P /opt/bin %flannel_url%
+                     ExecStart=/usr/bin/chmod +x /opt/bin/flanneld
+                 - name: flannel.service
+                   command: start
+                   content: |
+                     # Configures & starts flannel
+                     [Unit]
+                     After=network-online.target etcd.service flannel-install.service
+                     Requires=network-online.target etcd.service flannel-install.service
+
+                     [Service]
+                     ExecStartPre=/usr/bin/etcdctl mk /coreos.com/network/config '{"Network":"10.244.0.0/15", "Backend": {"Type": "vxlan"}}'
+                     ExecStart=/opt/bin/flanneld -iface=%kubernetes_net_interface%
+                     Restart=always
+                     RestartSec=5s
+                 - name: flannel-env.path
+                   command: start
+                   content: |
+                     # Ensures flannel env vars are set to use with Docker
+                     [Path]
+                     PathExists=/run/flannel/subnet.env
+                     Unit=docker.service
+                 - name: docker.service
+                   command: start
+                   content: |
+                     # Starts new docker server that uses flannel 
+                     [Unit]
+                     After=flannel-env.path network-online.target flannel.service
+                     Requires=flannel-env.path network-online.target flannel.service
+                     Description=Docker Application Container Engine
+
+                     [Service]
+                     EnvironmentFile=/run/flannel/subnet.env
+                     ExecStartPre=/bin/mount --make-rprivate /
+                     ExecStartPre=/usr/bin/systemctl kill docker.service
+                     ExecStart=/usr/bin/docker -d --bip=${FLANNEL_SUBNET} --mtu=${FLANNEL_MTU}
+
+                     [Install]
+                     WantedBy=multi-user.target
+           params:
+             "%discovery%": { get_attr: [discovery, networks, private, 0] }
+             "%uuid%": { get_attr: [coreos_cluster_uuid, value] }
+             "%flannel_url%": { get_param: flannel_url }
+             "%kubernetes_net_interface%": { get_param: kubernetes_net_interface }
+
+   kubernetes_minions:
+     type: "OS::Heat::ResourceGroup"
+     properties:
+       count: { get_param: kubernetes_minion_count }
+       resource_def:
+         type: OS::Nova::Server
+         properties:
+           key_name: { get_param: keyname }
+           image: { get_param: coreos_image }
+           flavor: { get_param: flavor }
+           name: kubernetes_minion_%index%
+           networks:
+           - uuid: "00000000-0000-0000-0000-000000000000"
+           - uuid: "11111111-1111-1111-1111-111111111111"
+           - uuid: { get_resource: priv_network }
+           user_data_format: RAW
+           config_drive: "true"
+           user_data:
+             str_replace:
+               template: |
+                 #cloud-config
+                 coreos:
+                   etcd:
+                     name: kubernetes_minion_%index%
+                     discovery: http://%discovery%:2379/v2/keys/discovery/%uuid%
+                     addr: $private_ipv4:4001
+                     peer-addr: $private_ipv4:7001
+                   fleet:
+                     public-ip: $private_ipv4
+                     metadata: kubernetes_role=minion
+                   update:
+                     group: stable
+                     reboot-strategy: off
+                   units:
+                     - name: etcd.service
+                       command: start
+                     - name: fleet.service
+                       command: start
+                     - name: flannel-install.service
+                       command: start
+                       content: |
+                         # Installs flannel
+                         [Unit]
+                         After=network-online.target
+                         Requires=network-online.target
+
+                         [Service]
+                         Type=oneshot
+                         RemainAfterExit=yes
+                         ExecStart=/usr/bin/wget -N -P /opt/bin %flannel_url%
+                         ExecStart=/usr/bin/chmod +x /opt/bin/flanneld
+                     - name: flannel.service
+                       command: start
+                       content: |
+                         # Configures & starts flannel
+                         [Unit]
+                         After=etcd.service flannel-install.service
+                         Requires=etcd.service flannel-install.service
+
+                         [Service]
+                         ExecStart=/opt/bin/flanneld -iface=%kubernetes_net_interface%
+                         Restart=always
+                         RestartSec=5s
+                     - name: flannel-env.path
+                       command: start
+                       content: |
+                         # Ensures flannel env vars are set to use with Docker
+                         [Path]
+                         PathExists=/run/flannel/subnet.env
+                         Unit=docker.service
+                     - name: docker.service
+                       command: start
+                       content: |
+                         # Starts new docker server that uses flannel 
+                         [Unit]
+                         After=flannel-env.path network-online.target flannel.service
+                         Requires=flannel-env.path network-online.target flannel.service
+                         Description=Docker Application Container Engine
+
+                         [Service]
+                         EnvironmentFile=/run/flannel/subnet.env
+                         ExecStartPre=/bin/mount --make-rprivate /
+                         ExecStartPre=/usr/bin/systemctl kill docker.service
+                         ExecStart=/usr/bin/docker -d --bip=${FLANNEL_SUBNET} --mtu=${FLANNEL_MTU}
+
+                         [Install]
+                         WantedBy=multi-user.target
+               params:
+                 "%discovery%": { get_attr: [discovery, networks, private, 0] }
+                 "%uuid%": { get_attr: [coreos_cluster_uuid, value] }
+                 "%flannel_url%": { get_param: flannel_url }
+                 "%kubernetes_net_interface%": { get_param: kubernetes_net_interface }
+
+ outputs:
+   discovery_ip:
+     value: { get_attr: [ discovery, accessIPv4 ] }
+     description: The IP of the Discovery
+   overlord_ip:
+     value: { get_attr: [ overlord, accessIPv4 ] }
+     description: The IP of the Overlord
+   master_ip:
+     value: { get_attr: [ kubernetes_master, accessIPv4 ] }
+     description: The IP of the Kubernetes Master
+   minion_ips:
+     value: { get_attr: [ kubernetes_minions, accessIPv4 ] }
+     description: The IP of the Kubernetes Minions

--- a/corekube-onmetal.yaml
+++ b/corekube-onmetal.yaml
@@ -21,8 +21,10 @@
      constraints:
      - allowed_values:
        - OnMetal Compute v1
+       - OnMetal IO v1
+       - OnMetal Memory v1 
        description: |
-         Must be a valid Rackspace Cloud Server flavor for the region you have
+         Must be a valid Rackspace OnMetal flavor for the region you have
          selected to deploy into.
    flavor_discovery:
      type: string
@@ -72,9 +74,12 @@
      type: string
      description: Host network interface for which Kubernetes' overlay will operate over
      default: "bond0.401"
+   cluster_subnet:
+     type: string
+     description: cluster subnet that containers will operate over
+     default: "10.244.0.0/15"
 
  resources:
-
    coreos_cluster_uuid:
      type: OS::Heat::RandomString
 
@@ -302,7 +307,7 @@
                      Requires=network-online.target etcd.service flannel-install.service
 
                      [Service]
-                     ExecStartPre=/usr/bin/etcdctl mk /coreos.com/network/config '{"Network":"10.244.0.0/15", "Backend": {"Type": "udp"}}'
+                     ExecStartPre=/usr/bin/etcdctl mk /coreos.com/network/config '{"Network":"%cluster_subnet%", "Backend": {"Type": "udp"}}'
                      ExecStart=/opt/bin/flanneld -iface=%kubernetes_net_interface%
                      Restart=always
                      RestartSec=5s
@@ -335,6 +340,7 @@
              "%uuid%": { get_attr: [coreos_cluster_uuid, value] }
              "%flannel_url%": { get_param: flannel_url }
              "%kubernetes_net_interface%": { get_param: kubernetes_net_interface }
+             "%cluster_subnet%": { get_param: cluster_subnet }
 
    kubernetes_minions:
      type: "OS::Heat::ResourceGroup"

--- a/corekube-onmetal.yaml
+++ b/corekube-onmetal.yaml
@@ -15,7 +15,7 @@
    keyname:
      type: string
      description: Name of keypair to be used for compute instance
-   flavor:
+   flavor_cluster:
      type: string
      default: OnMetal Compute v1
      constraints:
@@ -24,10 +24,24 @@
        description: |
          Must be a valid Rackspace Cloud Server flavor for the region you have
          selected to deploy into.
-   coreos_image:
+   flavor_admin:
+     type: string
+     default: 4 GB General Purpose v1
+     constraints:
+     - allowed_values:
+       - 4 GB General Purpose v1
+       - 8 GB General Purpose v1
+       description: |
+         Must be a valid Rackspace Cloud Server flavor for the region you have
+         selected to deploy into.
+   coreos_image_cluster:
      type: string
      description: Rackspace Cloud Servers CoreOS Stable (633.1.0) UUID
      default: "97646707-08ba-4b9c-bd85-91e976ebcadf"
+   coreos_image_admin:
+     type: string
+     description: Rackspace Cloud Servers CoreOS Stable (633.1.0) UUID
+     default: "a41d8b7c-d41b-4369-a180-0734f3b1cd8c"
    git_command:
      type: string
      description: Git repo checkout command
@@ -43,7 +57,7 @@
    kubernetes_net_interface:
      type: string
      description: Host network interface for which Kubernetes' overlay will operate over
-     default: "eth2"
+     default: "eth1"
 
  resources:
 
@@ -54,8 +68,8 @@
      type: OS::Nova::Server
      properties:
        key_name: { get_param: keyname }
-       image: { get_param: coreos_image }
-       flavor: { get_param: flavor }
+       image: { get_param: coreos_image_admin }
+       flavor: { get_param: flavor_admin }
        name: "discovery"
        user_data_format: RAW
        config_drive: "true"
@@ -114,8 +128,8 @@
      type: OS::Nova::Server
      properties:
        key_name: { get_param: keyname }
-       image: { get_param: coreos_image }
-       flavor: { get_param: flavor }
+       image: { get_param: coreos_image_admin }
+       flavor: { get_param: flavor_admin }
        name: "overlord"
        user_data_format: RAW
        config_drive: "true"
@@ -188,8 +202,8 @@
      type: OS::Nova::Server
      properties:
        key_name: { get_param: keyname }
-       image: { get_param: coreos_image }
-       flavor: { get_param: flavor }
+       image: { get_param: coreos_image_cluster }
+       flavor: { get_param: flavor_cluster }
        name: "kubernetes_master"
        networks:
        - uuid: "00000000-0000-0000-0000-000000000000"
@@ -263,7 +277,7 @@
                      Requires=network-online.target etcd.service flannel-install.service
 
                      [Service]
-                     ExecStartPre=/usr/bin/etcdctl mk /coreos.com/network/config '{"Network":"10.244.0.0/15", "Backend": {"Type": "vxlan"}}'
+                     ExecStartPre=/usr/bin/etcdctl mk /coreos.com/network/config '{"Network":"10.244.0.0/15", "Backend": {"Type": "udp"}}'
                      ExecStart=/opt/bin/flanneld -iface=%kubernetes_net_interface%
                      Restart=always
                      RestartSec=5s
@@ -305,8 +319,8 @@
          type: OS::Nova::Server
          properties:
            key_name: { get_param: keyname }
-           image: { get_param: coreos_image }
-           flavor: { get_param: flavor }
+           image: { get_param: coreos_image_cluster }
+           flavor: { get_param: flavor_cluster }
            name: kubernetes_minion_%index%
            networks:
            - uuid: "00000000-0000-0000-0000-000000000000"

--- a/corekube-onmetal.yaml
+++ b/corekube-onmetal.yaml
@@ -140,9 +140,9 @@
              coreos:
                etcd:
                  name: overlord
-                 discovery: http://%discovery%:2379/v2/keys/discovery/%uuid%
                  addr: $private_ipv4:4001
                  peer-addr: $private_ipv4:7001
+                 discovery: http://%discovery%:2379/v2/keys/discovery/%uuid%
                update:
                  group: stable
                  reboot-strategy: off
@@ -228,9 +228,9 @@
              coreos:
                etcd:
                  name: kubernetes_master
-                 discovery: http://%discovery%:2379/v2/keys/discovery/%uuid%
                  addr: $private_ipv4:4001
                  peer-addr: $private_ipv4:7001
+                 discovery: http://%discovery%:2379/v2/keys/discovery/%uuid%
                fleet:
                  public-ip: $private_ipv4
                  metadata: kubernetes_role=master
@@ -334,9 +334,9 @@
                  coreos:
                    etcd:
                      name: kubernetes_minion_%index%
-                     discovery: http://%discovery%:2379/v2/keys/discovery/%uuid%
                      addr: $private_ipv4:4001
                      peer-addr: $private_ipv4:7001
+                     discovery: http://%discovery%:2379/v2/keys/discovery/%uuid%
                    fleet:
                      public-ip: $private_ipv4
                      metadata: kubernetes_role=minion


### PR DESCRIPTION
Since Cloud Networks aren't available OnMetal I did the following:
- OnMetal Kubernetes Cluster uses ServiceNet and flannel backend type UDP
- Separated out Discovery and Overlord roles so that they can continue to use General Purpose flavors and accompanying images
- Kubernetes Master and Minions as OnMetal flavors
- Added a default network interface of bond0.401 for OnMetal Servers (as opposed to eth2)
- Added systemd unit to set /run/systemd/system/etcd.service.d/20-cloudinit.conf with correct servicenet ip address (the cloud-config magic variable $private_ipv4 doesn't work in OnMetal)
- Created a parameter so that users can specify the cluster subnet (default is still 10.244.0.0/15)